### PR TITLE
Dynamic property deprecation fix: Define container for Retry

### DIFF
--- a/src/Retry.php
+++ b/src/Retry.php
@@ -4,6 +4,8 @@ namespace Retry;
 
 class Retry
 {
+    private $container;
+
     public function __construct()
     {
         $this->container = new Container();


### PR DESCRIPTION
```
Creation of dynamic property Retry\Retry::$container is deprecated
```